### PR TITLE
Set constant line-height on keypad

### DIFF
--- a/src/css/scp-3125.css
+++ b/src/css/scp-3125.css
@@ -9,7 +9,7 @@
   border: 2px solid #1F0D12;
   box-shadow: 0 3px 5px black, 0 3px 9px rgba(0, 0, 0, 0.5);
   border-spacing: 6px; 
-  line-height: normal;
+  line-height: 30px;
 }
 
 .keypad-readout {


### PR DESCRIPTION
There's a tiny issue right now where when the post-DENIED text appears, the line height of the text box increases to accommodate the larger symbol on at least some browsers, resulting in a sudden and obvious transition where the buttons move up and down. With a constant line-height, that jolt no longer occurs, and the effect is far more subtle.