### PR TITLE
Include mandatory wikiwalk footer

### DIFF
--- a/src/wikidot/template.txt
+++ b/src/wikidot/template.txt
@@ -9,3 +9,11 @@
 
 [!-- This tag embeds everything in a <body> which sucks... --]
 [[html]]###templatedHtml###[[/html]]
+
+[[footnoteblock]]
+
+[[div class="footer-wikiwalk-nav"]]
+[[=]]
+<< [[[SCP-3124]]] | SCP-3125 | [[[SCP-3126]]] >>
+[[/=]]
+[[/div]]


### PR DESCRIPTION
Looks like this is a new recent development on the SCP wiki. I very nearly blanked it in my most recent update.