### PR TITLE
Bump up font size for the secret breadcrumb

### DIFF
--- a/src/wikidot/template.txt
+++ b/src/wikidot/template.txt
@@ -5,7 +5,7 @@
 }
 
 #breadcrumbs a:last-of-type:after {
-  font-size: 12.8px;
+  font-size: 15.2px;
   content: "Five Five Five Five Five";
 }
 [[/module]]


### PR DESCRIPTION
Should fix this issue:

![image](https://github.com/qntm/scp-3125/assets/1735353/beda811a-b326-40ca-b39a-3fcb32b25da6)
